### PR TITLE
Package cleanup and streamlined imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Launch the Streamlit app from the project root:
 
 
 ```bash
-streamlit run dashboard/app.py
+streamlit run src/dashboard/app.py
 ```
 
 The sidebar lets you kick off scans on your chosen domain.  Results are displayed in tables with a light theme similar to UpGuard.

--- a/run_all.py
+++ b/run_all.py
@@ -1,11 +1,5 @@
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import argparse
-import os
-import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "src"))
 from src.Scanners.run_scanners import run_all
 
 

--- a/src/ML/risk_model.py
+++ b/src/ML/risk_model.py
@@ -1,7 +1,3 @@
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
 import json
 import os
 import argparse

--- a/src/Scanners/port_scanner.py
+++ b/src/Scanners/port_scanner.py
@@ -1,9 +1,4 @@
 # scanners/port_scanner.py
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
-
 import nmap
 import os
 from datetime import datetime

--- a/src/Scanners/run_scanners.py
+++ b/src/Scanners/run_scanners.py
@@ -1,9 +1,5 @@
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
-import os
 import json
+import os
 from datetime import datetime
 from concurrent.futures import ThreadPoolExecutor
 

--- a/src/Scanners/ssl_checker.py
+++ b/src/Scanners/ssl_checker.py
@@ -1,7 +1,3 @@
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
 import ssl
 import socket
 import json

--- a/src/Scanners/subdomain_scanner.py
+++ b/src/Scanners/subdomain_scanner.py
@@ -1,7 +1,4 @@
 # scanners/subdomain_scanner.py
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 import subprocess
 import socket
 import os

--- a/src/Scanners/tech_scanner.py
+++ b/src/Scanners/tech_scanner.py
@@ -1,7 +1,3 @@
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
 import argparse
 import os
 import re

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,8 +1,4 @@
 """Streamlit dashboard for running scanners and viewing risk scores."""
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-
 
 from pathlib import Path
 import streamlit as st


### PR DESCRIPTION
## Summary
- make `src` a real Python package
- drop all `sys.path` manipulation
- provide a CLI for leak classification
- update README and scripts to reference the `src` package

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run_all.py --help` *(fails: ModuleNotFoundError: No module named 'nmap')*

------
https://chatgpt.com/codex/tasks/task_e_68480ea2d22483239e7f8d52ea4f6a77